### PR TITLE
Oppdatert fra NAV til Nav i ekstern varsling

### DIFF
--- a/src/main/kotlin/no/nav/syfo/sykmeldingvarsel/doknotifikasjon/Doknotifikasjon.kt
+++ b/src/main/kotlin/no/nav/syfo/sykmeldingvarsel/doknotifikasjon/Doknotifikasjon.kt
@@ -9,7 +9,7 @@ const val SMS_TEKST =
 Hei!
 Du har fått tilgang til sykmeldingen til en av dine ansatte.
 Logg inn på "Min side - arbeidsgiver" og finn sykmeldingen der. 
-Vennlig hilsen NAV
+Vennlig hilsen Nav
 """
 const val EPOST_TEKST =
     """
@@ -24,7 +24,7 @@ const val EPOST_TEKST =
 <p>Logg inn på "Min side - arbeidsgiver", trykk på "Sykmeldte" og finn sykmeldingen der.</p>
 <p>Du må logge inn med BankID eller tilsvarende for at vi skal være sikre på at sykmeldingen kommer fram til rett person.</p>
 <p>Vennlig hilsen</p>
-<p> NAV</p>
+<p>Nav</p>
 </body>
 </html>
 """


### PR DESCRIPTION
Hei, ser i doknotifikasjon at appen deres bestiller ekstern varsling med gammel stavemåte for Nav.

* Oppdatert til ny skrivemåte
* Fjernet ekstra mellomrom